### PR TITLE
Fix warning about needing to instantiate on main

### DIFF
--- a/ios/Services/AudioService/AudioPreviewServiceModule.swift
+++ b/ios/Services/AudioService/AudioPreviewServiceModule.swift
@@ -3,7 +3,11 @@ import VoxeetSDK
 
 @objc(RNAudioPreviewServiceModule)
 public class AudioPreviewServiceModule: ReactEmitter {
-	
+
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	public override init() {
 		super.init()
 		VoxeetSDK.shared.audio.local.preview.onStatusChanged

--- a/ios/Services/AudioService/LocalAudioServiceModule.swift
+++ b/ios/Services/AudioService/LocalAudioServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNLocalAudioServiceModule)
 public class LocalAudioServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     /// Returns the local participant's audio capture mode in Dolby Voice conferences.
     /// - Parameters:
     ///   - resolve: returns ComfortNoiseLevel on success

--- a/ios/Services/AudioService/RemoteAudioServiceModule.swift
+++ b/ios/Services/AudioService/RemoteAudioServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNRemoteAudioServiceModule)
 public class RemoteAudioServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     /// Allows the local participant to unmute a specific remote participant who is locally muted through the stop method.
     /// - Parameters:
     ///   - participant: The selected remote participant who is locally muted through the stop method.

--- a/ios/Services/CommandService/CommandServiceModule.swift
+++ b/ios/Services/CommandService/CommandServiceModule.swift
@@ -9,6 +9,10 @@ private enum EventKeys: String, CaseIterable {
 @objc(RNCommandServiceModule)
 public class CommandServiceModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	// MARK: - Events Setup
 	@objc(supportedEvents)
 	override public func supportedEvents() -> [String] {

--- a/ios/Services/CommsAPIModule.swift
+++ b/ios/Services/CommsAPIModule.swift
@@ -12,6 +12,10 @@ private let sdkVersion = "3.10.1"
 @objc(RNCommsAPIModule)
 public class CommsAPIModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	private var refreshToken: ((String?) -> Void)?
 
 	// MARK: - Events Setup

--- a/ios/Services/ConferenceService/ConferenceServiceModule.swift
+++ b/ios/Services/ConferenceService/ConferenceServiceModule.swift
@@ -21,6 +21,11 @@ private enum EventKeys: String, CaseIterable {
 
 @objc(RNConferenceServiceModule)
 public class ConferenceServiceModule: ReactEmitter {
+
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	var current: VTConference? {
 		VoxeetSDK.shared.conference.current
 	}

--- a/ios/Services/FilePresentationService/FilePresentationServiceModule.swift
+++ b/ios/Services/FilePresentationService/FilePresentationServiceModule.swift
@@ -16,6 +16,10 @@ private enum EventKeys: String, CaseIterable {
 @objc(RNFilePresentationServiceModule)
 public class FilePresentationServiceModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	@Atomic
 	private var fileConvertedCache: [String: VTFileConverted] = [:]
 

--- a/ios/Services/MediaDeviceService/MediaDeviceServiceModule.swift
+++ b/ios/Services/MediaDeviceService/MediaDeviceServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNMediaDeviceServiceModule)
 public class MediaDeviceServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	/// Changes the device camera (front or back).
 	/// - Parameters:
 	///   - resolve: returns on success

--- a/ios/Services/NotificationService/NotificationServiceModule.swift
+++ b/ios/Services/NotificationService/NotificationServiceModule.swift
@@ -16,6 +16,10 @@ private enum EventKeys: String, CaseIterable {
 @objc(RNNotificationServiceModule)
 public class NotificationServiceModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	// MARK: - Events Setup
 	@objc(supportedEvents)
 	override public func supportedEvents() -> [String] {

--- a/ios/Services/RecordingService/RecordingServiceModule.swift
+++ b/ios/Services/RecordingService/RecordingServiceModule.swift
@@ -10,6 +10,10 @@ private enum EventKeys: String, CaseIterable {
 @objc(RNRecordingServiceModule)
 public class RecordingServiceModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	@Atomic
 	private var currentRecording: RecordingModel?
 

--- a/ios/Services/SessionService/SessionServiceModule.swift
+++ b/ios/Services/SessionService/SessionServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNSessionServiceModule)
 public class SessionServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	/// Opens a new session.
 	/// - Parameters:
 	///   - userInfo: user info

--- a/ios/Services/VideoPresentationService/VideoPresentationServiceModule.swift
+++ b/ios/Services/VideoPresentationService/VideoPresentationServiceModule.swift
@@ -18,6 +18,10 @@ private enum EventKeys: String, CaseIterable {
 @objc(RNVideoPresentationServiceModule)
 public class VideoPresentationServiceModule: ReactEmitter {
 
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
 	// MARK: - Events Setup
 	@objc(supportedEvents)
 	override public func supportedEvents() -> [String] {

--- a/ios/Services/VideoService/LocalVideoServiceModule.swift
+++ b/ios/Services/VideoService/LocalVideoServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNLocalVideoServiceModule)
 public class LocalVideoServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     /// Enables the local participant's video and sends the video to a conference.
     /// - Parameters:
     ///   - resolve: returns on success

--- a/ios/Services/VideoService/RemoteVideoServiceModule.swift
+++ b/ios/Services/VideoService/RemoteVideoServiceModule.swift
@@ -4,6 +4,10 @@ import VoxeetSDK
 @objc(RNRemoteVideoServiceModule)
 public class RemoteVideoServiceModule: NSObject {
 
+    @objc public static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     /// If the local participant used the stop method to stop receiving video streams from selected remote participants.
     /// - Parameters:
     ///   - participant: The selected remote participant who is locally muted through the stop method.


### PR DESCRIPTION
For iOS we are now indicating through `requiresMainQueueSetup()` returning false that modules do not need to be instantiated on the main thread.